### PR TITLE
Add customizable fields for OneAgent objects

### DIFF
--- a/dynatrace-oneagent-operator/templates/Common/configmap.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/configmap.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Dynatrace LLC
+# Copyright 2020 Dynatrace LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,31 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-platform: "kubernetes"
-
-operator:
-  image: ""
-
-oneagent:
-  name: "oneagent"
-  apiUrl: ""
-  image: ""
-  args:
-    - --set-app-log-content-access=true
-  env: []
-  nodeSelector: {}
-  labels: {}
-  skipCertCheck: false
-  disableAgentUpdate: false
-  enableIstio: false
-  dnsPolicy: ""
-  resources: {}
-  waitReadySeconds: null
-  priorityClassName: ""
-  serviceAccountName: ""
-  proxy: ""
-  trustedCAs: ""
-
-secret:
-  apiToken: ""
-  paasToken: ""
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
+{{- if .Values.oneagent.trustedCAs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.oneagent.name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  certs: |
+{{ .Values.oneagent.trustedCAs | indent 4 }}
+{{- end }}

--- a/dynatrace-oneagent-operator/templates/Common/customresource.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/customresource.yaml
@@ -19,13 +19,67 @@ metadata:
   name: {{ .Values.oneagent.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  apiUrl: {{ required "ApiUrl needs to be set!" .Values.oneagent.apiUrl}}
-  tokens: {{ .Values.secret.name }}
-  skipCertCheck: false
+  apiUrl: {{ required "ApiUrl needs to be set!" .Values.oneagent.apiUrl }}
+  tokens: {{ .Values.oneagent.name }}
   image: {{ include "dynatrace-oneagent.image" . }}
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Exists
-  args:
-  - APP_LOG_CONTENT_ACCESS=1
+
+  {{- if .Values.oneagent.args }}
+  args: {{- toYaml .Values.oneagent.args | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.env }}
+  env: {{- toYaml .Values.oneagent.env | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.labels }}
+  labels: {{- toYaml .Values.oneagent.labels  | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.nodeSelector }}
+  nodeSelector: {{- toYaml .Values.oneagent.nodeSelector | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.proxy }}
+  proxy:
+    valueFrom: {{ .Values.oneagent.name }}
+  {{- end }}
+
+  {{- if .Values.oneagent.tolerations }}
+  tolerations: {{- toYaml .Values.oneagent.tolerations | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.resources }}
+  resources: {{- toYaml .Values.oneagent.resources | nindent 4 }}
+  {{- end }}
+
+  {{- if .Values.oneagent.dnsPolicy }}
+  dnsPolicy: {{ .Values.oneagent.dnsPolicy }}
+  {{- end }}
+
+  {{- if .Values.oneagent.enableIstio }}
+  enableIstio: {{ .Values.oneagent.enableIstio }}
+  {{- end }}
+
+  {{- if .Values.oneagent.disableAgentUpdate }}
+  disableAgentUpdate: {{ .Values.oneagent.disableAgentUpdate }}
+  {{- end }}
+
+  {{- if .Values.oneagent.skipCertCheck }}
+  skipCertCheck: {{ .Values.oneagent.skipCertCheck }}
+  {{- end }}
+
+  {{- if .Values.oneagent.waitReadySeconds }}
+  waitReadySeconds: {{ .Values.oneagent.waitReadySeconds }}
+  {{- end }}
+
+  {{- if .Values.oneagent.priorityClassName }}
+  priorityClassName: {{ .Values.oneagent.priorityClassName }}
+  {{- end }}
+
+  {{- if .Values.oneagent.serviceAccountName }}
+  serviceAccountName: {{ .Values.oneagent.serviceAccountName }}
+  {{- end }}
+
+  {{- if .Values.oneagent.trustedCAs }}
+  trustedCAs: {{ .Values.oneagent.name }}
+  {{- end }}

--- a/dynatrace-oneagent-operator/templates/Common/deployment.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/deployment.yaml
@@ -57,7 +57,28 @@ spec:
             limits:
               cpu: 100m
               memory: 256Mi
-      nodeSelector:
-        beta.kubernetes.io/os: linux
-        beta.kubernetes.io/arch: amd64
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       serviceAccountName: {{ .Release.Name }}

--- a/dynatrace-oneagent-operator/templates/Common/secret.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/secret.yaml
@@ -16,9 +16,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secret.name }}
+  name: {{ .Values.oneagent.name }}
   namespace: {{ .Release.Namespace }}
 data:
   apiToken: {{ .Values.secret.apiToken | b64enc }}
   paasToken: {{ .Values.secret.paasToken | b64enc }}
+  {{- if .Values.oneagent.proxy }}
+  proxy: {{ .Values.oneagent.proxy | b64enc }}
+  {{- end }}
 type: Opaque


### PR DESCRIPTION
On this PR I'm adding Helm config fields for the rest of OneAgent CR options.

One thing I'm changing is to use the {{oneagent.name}} for also the name of the Secret (and the new ConfigMap) since we're creating them anyway, and don't see a need to customize it.

The proxy is stored automatically on the same Secret we use for the tokens, and referenced on the OneAgent CR. Same for the trustedCAs field where we put it on a ConfigMap and add the name to the CR. The other fields are just copied from values to the CR.