### PR TITLE
Use GitHub link for overview diagram

### DIFF
--- a/dynatrace-oneagent-operator/README.md
+++ b/dynatrace-oneagent-operator/README.md
@@ -13,7 +13,7 @@ The rollout of the Dynatrace OneAgent is managed by a DaemonSet initially.
 From here on the Dynatrace OneAgent Operator controls the lifecycle and keeps track of new versions and triggers updates if required.
 The Dynatrace OneAgent Operator's Helm Chart will also roll out the actual OneAgent automatically during installation.
 
-![Overview](./overview.svg)
+![Overview](https://github.com/Dynatrace/helm-charts/blob/53189b5a740af26b8d87c0dd30ef9c653552610b/dynatrace-oneagent-operator/overview.svg)
 
 
 ## Requirements


### PR DESCRIPTION
The URL `./overview.svg` is not available on [Helm Hub](https://hub.helm.sh/charts/dynatrace/dynatrace-oneagent-operator/0.7.0) so it looks like this,

![image](https://user-images.githubusercontent.com/452407/78243894-e4e80d80-74e4-11ea-9498-1fbfb320b4b7.png)

Replacing it with link to the file in GitHub itself.