### PR TITLE
Add parameter to optionally create the secret

### DIFF
--- a/dynatrace-oneagent-operator/templates/Common/secret.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/secret.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
+{{- if .Values.secret.autoCreate }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,3 +26,4 @@ data:
   proxy: {{ .Values.oneagent.proxy | b64enc }}
   {{- end }}
 type: Opaque
+{{- end }}

--- a/dynatrace-oneagent-operator/values.yaml
+++ b/dynatrace-oneagent-operator/values.yaml
@@ -44,5 +44,6 @@ oneagent:
   trustedCAs: ""
 
 secret:
+  autoCreate: true
   apiToken: ""
   paasToken: ""


### PR DESCRIPTION
Added an additional parameter to let the customer decide if he wants to get the secret automatically generated or not:
secret.autoCreate: true (default)