### PR TITLE
admissionregistration.k8s.io/v1beta1 deprecated

### DIFF
--- a/dynatrace-oneagent-operator-google-marketplace/chart/dynatrace-oneagent-operator/templates/configmap.yaml
+++ b/dynatrace-oneagent-operator-google-marketplace/chart/dynatrace-oneagent-operator/templates/configmap.yaml
@@ -672,7 +672,7 @@ data:
         served: true
         storage: true
   mutatingwebhookconfiguration.yaml: |
-    apiVersion: admissionregistration.k8s.io/v1beta1
+    apiVersion: admissionregistration.k8s.io/v1
     kind: MutatingWebhookConfiguration
     metadata:
       name: dynatrace-oneagent-webhook

--- a/dynatrace-oneagent-operator/templates/Common/mutatingwebhookconfiguration.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/mutatingwebhookconfiguration.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: dynatrace-oneagent-webhook


### PR DESCRIPTION
Replacing admissionregistration.k8s.io/v1beta1 by admissionregistration.k8s.io/v1