### PR TITLE
Optional PSP creation

### DIFF
--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-oneagent.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-oneagent.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
+{{- if and (eq .Values.platform "kubernetes") (.Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-oneagent.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-oneagent.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if eq .Values.platform "kubernetes" }}
+{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-operator.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-operator.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
+{{- if and (eq .Values.platform "kubernetes") (.Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-operator.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-operator.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if eq .Values.platform "kubernetes" }}
+{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-webhook.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-webhook.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
+{{- if and (eq .Values.platform "kubernetes") (.Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-webhook.yaml
+++ b/dynatrace-oneagent-operator/templates/Kubernetes/podsecuritypolicy-webhook.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
-{{- if eq .Values.platform "kubernetes" }}
+{{- if and (eq .Values.platform "kubernetes") (not .Values.createPsp)}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/dynatrace-oneagent-operator/values.yaml
+++ b/dynatrace-oneagent-operator/values.yaml
@@ -15,7 +15,7 @@
 platform: "kubernetes"
 mode: "fullstack"
 
-# In case you don't want PSP to bee created by this chart
+# In case you don't want PSP to be created by this chart
 createPsp: false
 
 operator:

--- a/dynatrace-oneagent-operator/values.yaml
+++ b/dynatrace-oneagent-operator/values.yaml
@@ -14,6 +14,8 @@
 
 platform: "kubernetes"
 mode: "fullstack"
+
+# In case you don't want PSP to bee created by this chart
 createPsp: false
 
 operator:

--- a/dynatrace-oneagent-operator/values.yaml
+++ b/dynatrace-oneagent-operator/values.yaml
@@ -14,6 +14,7 @@
 
 platform: "kubernetes"
 mode: "fullstack"
+createPsp: false
 
 operator:
   image: ""


### PR DESCRIPTION
In order to make Kubernetes PSP creation optional, we added an additional `createPsp` boolean value.
If true, PSP will be created as before.
If false, no PSP will be created by this chart.

This is intended to let CISO be as paranoid as wanted :)
In our case, we have to control all PSP created/used in our Kubernetes platform, thus we cannot let additional tools create their own.
