### PR TITLE
kubernetes cluster monitoring

### DIFF
--- a/dynatrace-oneagent-operator/templates/Common/clusterrole-monitor.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/clusterrole-monitor.yaml
@@ -1,0 +1,45 @@
+# Copyright 2019 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
+{{- if .Values.monitor.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dynatrace-monitoring-cluster
+rules:
+  - apiGroups:
+      - ""
+      - batch
+      - apps
+      - apps.openshift.io
+    resources:
+      - nodes
+      - pods
+      - namespaces
+      - deployments
+      - replicasets
+      - deploymentconfigs
+      - replicationcontrollers
+      - jobs
+      - cronjobs
+      - statefulsets
+      - daemonsets
+      - events
+      - resourcequotas
+    verbs:
+      - list
+      - watch
+      - get
+{{- end }}

--- a/dynatrace-oneagent-operator/templates/Common/clusterrolebinding-monitor.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/clusterrolebinding-monitor.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
+{{- if .Values.monitor.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dynatrace-monitoring-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dynatrace-monitoring-cluster
+subjects:
+  - kind: ServiceAccount
+    name: dynatrace-monitoring
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/dynatrace-oneagent-operator/templates/Common/serviceaccount-monitor.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/serviceaccount-monitor.yaml
@@ -1,0 +1,22 @@
+# Copyright 2019 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes or openshift" (include "dynatrace-oneagent-operator.platformSet" .))}}
+{{- if .Values.monitor.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-monitoring
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/dynatrace-oneagent-operator/values.yaml
+++ b/dynatrace-oneagent-operator/values.yaml
@@ -49,3 +49,7 @@ secret:
   autoCreate: true
   apiToken: ""
   paasToken: ""
+
+# Enable kubernetes cluster monitoring
+monitor:
+  enable: false


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
Following this documentation: [kubernetes monitoring with dynatrace](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/monitoring/monitor-kubernetes-clusters-with-dynatrace/#expand-1022kubernetes-monitoring-service-accountyaml)

I add the equivalent of the manifest into helm template.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I would like to give the possibility to user to enable or not kubernetes cluster monitoring automatically when user deploy oneagent.

When we are deploying on kubernetes only with terraform helm_release and not with kubectl, it could be fine.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes. This feature is disabled by default.
