### PR TITLE
fix: Correct metrics port

### DIFF
--- a/dynatrace-oneagent-operator/templates/Common/deployment-operator.yaml
+++ b/dynatrace-oneagent-operator/templates/Common/deployment-operator.yaml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
           ports:
-            - containerPort: 60000
+            - containerPort: 8080
               name: metrics
           resources:
             requests:


### PR DESCRIPTION
Hello,

The one-agent-operator exposes the 8080 port for prometheus metrics but the container yaml exposes the 60000 port. This PR fixes this issue.