### PR TITLE
Fix trustedCA field in dynakube

### DIFF
--- a/dynatrace-operator/templates/Common/customresource-dynakube.yaml
+++ b/dynatrace-operator/templates/Common/customresource-dynakube.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
 
   {{- if .Values.trustedCAs }}
-  trustedCAs: {{ .Values.trustedCAs }}
+  trustedCAs: {{ .Values.name }}
   {{- end }}
 
   {{- if .Values.networkZone }}

--- a/dynatrace-operator/tests/Common/customresource-dynakube_test.yaml
+++ b/dynatrace-operator/tests/Common/customresource-dynakube_test.yaml
@@ -65,13 +65,14 @@ tests:
       apiUrl: test-api-url
       apiToken: test-api-token
       paasToken: test-paas-token
+      name: test-name
       trustedCAs: test-ca
     asserts:
       - isNotNull:
           path: spec.trustedCAs
       - equal:
           path: spec.trustedCAs
-          value: test-ca
+          value: test-name
 
   - it: should add networkZone if set
     set:


### PR DESCRIPTION
Use name for trustedCA field, as operator finds corresponding configmap by this name.