### PR TITLE
Validation webhook only for dk updates

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/operator/clusterrole-operator.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/operator/clusterrole-operator.yaml
@@ -56,7 +56,24 @@ rules:
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - create
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
       - mutatingwebhookconfigurations
+    resourceNames:
+      - dynatrace-webhook
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
     resourceNames:
       - dynatrace-webhook
     verbs:

--- a/dynatrace-operator/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift or openshift-3-11" (include "dynatrace-operator.platformSet" .))}}
+{{- if ne .Values.platform "openshift-3-11"}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: dynatrace-webhook
+  labels:
+  {{- include "dynatrace-operator.commonlabelswebhook" . | nindent 4 }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+      - v1alpha1
+    clientConfig:
+      service:
+        name: dynatrace-webhook
+        namespace: dynatrace
+        path: /validate
+    rules:
+      - operations:
+          - UPDATE
+        apiGroups:
+          - dynatrace.com
+        apiVersions:
+          - v1alpha1
+        resources:
+          - dynakubes
+    name: webhook.dynatrace.com
+    sideEffects: None
+{{end}}

--- a/dynatrace-operator/chart/default/templates/application.yaml
+++ b/dynatrace-operator/chart/default/templates/application.yaml
@@ -67,6 +67,8 @@ spec:
     - group: v1
       kind: ServiceAccount
     - group: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+    - group: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
     - group: apps/v1
       kind: StatefulSet

--- a/dynatrace-operator/schema.yaml
+++ b/dynatrace-operator/schema.yaml
@@ -107,6 +107,11 @@ x-google-marketplace:
               - clusterroles
               - clusterrolebindings
             verbs: ["*"]
+          - apiGroups:
+              - admissionregistration.k8s.io
+            resources:
+              - validatingwebhookconfigurations
+            verbs: ["*"]
 
 properties:
   name:


### PR DESCRIPTION
Helm deploys the dynakube before the validation webhook is ready so the install will fail. 
I modified the configuration to only validate updates of dynakubes, and not creation.  