### PR TITLE
fix: Use Helm release's namespace to grant SCC

### DIFF
--- a/dynatrace-operator/chart/default/templates/Openshift/oneagent/securitycontextconstraints-unprivileged.yaml
+++ b/dynatrace-operator/chart/default/templates/Openshift/oneagent/securitycontextconstraints-unprivileged.yaml
@@ -59,7 +59,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-  - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent-unprivileged
+  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-dynakube-oneagent-unprivileged
 volumes:
   - "*"
 {{ end }}

--- a/dynatrace-operator/chart/default/templates/Openshift/oneagent/securitycontextconstraints.yaml
+++ b/dynatrace-operator/chart/default/templates/Openshift/oneagent/securitycontextconstraints.yaml
@@ -44,7 +44,7 @@ seccompProfiles:
 supplementalGroups:
   type: RunAsAny
 users:
-  - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent
+  - system:serviceaccount:{{ .Release.Namespace }}:dynatrace-dynakube-oneagent
 volumes:
   - "*"
 {{ end }}

--- a/dynatrace-operator/chart/default/tests/Openshift/oneagent/securitycontextconstraints-unprivileged_test.yaml
+++ b/dynatrace-operator/chart/default/tests/Openshift/oneagent/securitycontextconstraints-unprivileged_test.yaml
@@ -102,7 +102,7 @@ tests:
       - equal:
           path: users
           value:
-            - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent-unprivileged
+            - system:serviceaccount:NAMESPACE:dynatrace-dynakube-oneagent-unprivileged
       - equal:
           path: volumes
           value:

--- a/dynatrace-operator/chart/default/tests/Openshift/oneagent/securitycontextconstraints_test.yaml
+++ b/dynatrace-operator/chart/default/tests/Openshift/oneagent/securitycontextconstraints_test.yaml
@@ -86,7 +86,7 @@ tests:
       - equal:
           path: users
           value:
-            - system:serviceaccount:dynatrace:dynatrace-dynakube-oneagent
+            - system:serviceaccount:NAMESPACE:dynatrace-dynakube-oneagent
       - equal:
           path: volumes
           value:


### PR DESCRIPTION
If you install this chart to a custom namespace, in Openshift > 3.11, and want to run OneAgent with the min required permissions, you need this SCC granted to the SA OneAgent runs as. This PR fixes the grant