### PR TITLE
Removes CREATE operation for the validation webhook

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/webhook/validatingwebhookconfiguration.yaml
@@ -31,7 +31,6 @@ webhooks:
         path: /validate
     rules:
       - operations:
-          - CREATE
           - UPDATE
         apiGroups:
           - dynatrace.com


### PR DESCRIPTION
In case of helm we can't wait till the validation webhook gets ready before helm tries to apply the custom resource. which will cause a failed install. Also in case of helm the validation for the initial create is 'validated' by us when generating the yaml