### PR TITLE
Remove post-install hook from dynakube

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/customresource-dynakube.yaml
@@ -19,10 +19,6 @@
 apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
-  annotations:
-    {{- if ne .Values.platform "google"}}
-    "helm.sh/hook": post-install,post-upgrade
-    {{ end }}
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
* Resources created via post-install hook are not deleted when uninstalling the chart