### PR TITLE
Remove duplicate label on webhook (#160)

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.commonlabelswebhook" . | nindent 4 }}
-    dynatrace.com/operator: dynakube
 spec:
   replicas: 1
   revisionHistoryLimit: 1


### PR DESCRIPTION
Duplicate labels are blocking fluxcd integration for some customers.
Please 
- review
- apply on master
- apply on release-dto-3.0
- update release
Thx