### PR TITLE
Add securityContext to Deployments

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -34,6 +34,17 @@ spec:
         name: {{ .Release.Name }}
         {{- include "dynatrace-operator.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        # run container under uid 1000 (user id) and gid 1000 (group id)
+        # file access group for uid 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        supplementalGroups: [1000]
+        # enforce containers not to run as root
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: {{ .Release.Name }}
           args:
@@ -41,6 +52,15 @@ spec:
           # Replace this with the built image name
           image: {{- include "dynatrace-operator.image" . | nindent 12 }}
           imagePullPolicy: Always
+          securityContext:
+            # run container with readonly root filesystem (volumes are not affected)
+            readOnlyRootFilesystem: false
+            # enforce container not to run as root
+            runAsNonRoot: true
+            # don't allow suid/sgid binaries/calls (default: false)
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/dynatrace-operator/chart/default/templates/Common/operator/deployment-operator.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/operator/deployment-operator.yaml
@@ -82,10 +82,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: {{ .Values.operator.memory.requests }}
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: {{ .Values.operator.memory.limits }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -102,10 +102,10 @@ spec:
           resources:
             requests:
               cpu: 300m
-              memory: 128Mi
+              memory: {{ .Values.operator.memory.requests }}
             limits:
               cpu: 300m
-              memory: 128Mi
+              memory: {{ .Values.operator.memory.limits }}
       serviceAccountName: dynatrace-webhook
       {{- if .Values.operator.customPullSecret }}
       imagePullSecrets:

--- a/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/webhook/deployment-webhook.yaml
@@ -52,12 +52,32 @@ spec:
                     operator: In
                     values:
                       - linux
+      securityContext:
+        # run container under uid 1000 (user id) and gid 1000 (group id)
+        # file access group for uid 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        supplementalGroups: [1000]
+        # enforce containers not to run as root
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: webhook
           args:
             - webhook-server
           image: {{- include "dynatrace-operator.image" . | nindent 12 }}
           imagePullPolicy: Always
+          securityContext:
+            # run container with readonly root filesystem (volumes are not affected)
+            readOnlyRootFilesystem: false
+            # enforce container not to run as root
+            runAsNonRoot: true
+            # don't allow suid/sgid binaries/calls (default: false)
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/dynatrace-operator/chart/default/values.yaml
+++ b/dynatrace-operator/chart/default/values.yaml
@@ -38,6 +38,9 @@ operator:
   customPullSecret: ""
   nodeSelector: {}
   tolerations: {}
+  memory:
+    requests: 128Mi
+    limits: 128Mi
 
 createSecurityContextConstraints: true # Only applicable for Openshift
 


### PR DESCRIPTION
For security reasons the pods should be limited in their privileges.

https://kubernetes.io/docs/tasks/configure-pod-container/security-context/