### PR TITLE
Add v0.4.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,20 @@
 Here you will find helm charts for installing Dynatrace components on Kubernetes. For generic information about Helm Charts refer to [the Helm GitHub repository](https://github.com/helm/charts).
 
 ## dynatrace-operator chart
-The Helm chart for the dynatrace-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-operator/chart/default).
+> This repository is updated for backwards compatibility, the new helm repository is located in the [dynatrace-operator](https://github.com/Dynatrace/dynatrace-operator) repository.
+
+The Helm chart for the dynatrace-operator is located in the [dynatrace-operator repository](https://github.com/Dynatrace/dynatrace-operator/tree/master/config/helm/chart/default).
+
+You can move to the new helm repository with the following commands:
+1. Update the repo url
+```
+helm repo remove dynatrace
+helm repo add dynatrace https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable
+```
+2. Install a new version or upgrade from an existing version by following the instructions on the [dynatrace-operator Release page](https://github.com/Dynatrace/dynatrace-operator/releases)
 
 #### GKE
-The GKE chart for the dynatrace-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-operator/).
+The GKE chart for the dynatrace-operator is located in the [dynatrace-operator repository](https://github.com/Dynatrace/dynatrace-operator/tree/master/config/helm).
 
 ## dynatrace-oneagent-operator chart
 
@@ -17,4 +27,4 @@ The GKE chart for the dynatrace-operator lives [here](https://github.com/Dynatra
 The Helm chart for the dynatrace-oneagent-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-oneagent-operator/chart/default).
 
 #### GKE
-The GKE chart for the dynatrace-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-oneagent-operator/).
+The GKE chart for the dynatrace-oneagent-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-oneagent-operator/).

--- a/repos/stable/index.yaml
+++ b/repos/stable/index.yaml
@@ -300,6 +300,27 @@ entries:
     version: 0.5.4
   dynatrace-operator:
   - apiVersion: v2
+    appVersion: 0.4.2
+    created: '2022-02-15T16:50:00.153390163Z'
+    description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
+    digest: bd5ec00b917d84157bbc0a2676581979dc7c7f56728703436731a3cf94be7165
+    home: https://www.dynatrace.com/
+    icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
+    maintainers:
+    - email: marcell.sevcsik@dynatrace.com
+      name: 0sewa0
+    - email: christoph.muellner@dynatrace.com
+      name: chrismuellner
+    - email: lukas.hinterreiter@dynatrace.com
+      name: luhi-DT
+    name: dynatrace-operator
+    sources:
+    - https://github.com/Dynatrace/dynatrace-operator
+    type: application
+    urls:
+    - https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/master/config/helm/repos/stable/dynatrace-operator-0.4.2.tgz
+    version: 0.4.2
+  - apiVersion: v2
     appVersion: 0.4.1
     created: '2022-02-01T13:14:01.982041685Z'
     description: The Dynatrace Operator Helm chart for Kubernetes and OpenShift
@@ -440,4 +461,4 @@ entries:
     urls:
     - https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/dynatrace-operator-0.1.0.tgz
     version: 0.1.0
-generated: '2022-02-01T15:23:08.707359556Z'
+generated: '2022-02-15T16:50:00.153390163Z'


### PR DESCRIPTION
* Add `v0.4.2` release: https://github.com/Dynatrace/dynatrace-operator/releases/tag/v0.4.2
* Add information about move of helm repo