### PR TITLE
Update link to operator migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GKE chart for the dynatrace-operator is located in the [dynatrace-operator r
 ## dynatrace-oneagent-operator chart
 
 
->## **NOTE: The Dynatrace OneAgent Operator is deprecated and will not be supported anymore with Summer 2022. Please refer to [Migrating from OneAgent Operator to Dynatrace Operator](https://www.dynatrace.com/support/help/setup-and-configuration/setup-on-container-platforms/kubernetes/migrate-to-dynatrace-operator-k8/).**
+>## **NOTE: The Dynatrace OneAgent Operator is deprecated and will not be supported anymore with Summer 2022. Please refer to [Migrating from OneAgent Operator to Dynatrace Operator](https://dt-url.net/oneagent-operator-migration).**
 <br>
 
 The Helm chart for the dynatrace-oneagent-operator lives [here](https://github.com/Dynatrace/helm-charts/tree/master/dynatrace-oneagent-operator/chart/default).


### PR DESCRIPTION
Official documentation structure was changed so the links need to be updated to reflect these changes.