### PR TITLE
add imagecustomPullSecret option to csi daemonset

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/csi/daemonset.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/csi/daemonset.yaml
@@ -160,6 +160,10 @@ spec:
       securityContext: {}
       serviceAccount: dynatrace-oneagent-csi-driver
       serviceAccountName: dynatrace-oneagent-csi-driver
+      {{- if .Values.operator.customPullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.operator.customPullSecret }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - hostPath:


### PR DESCRIPTION
## Cause :
* Blocking issue for some organisation where there are a mirror/private registry to pull images from.
## Actions
* Enable `imagePullSecrets` injection if `operator.customPullsecret` option is present in values.
