### PR TITLE
Added required annotation for Dynatrace to collect metrics from K8S clusters

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/customresource-dynakube.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/customresource-dynakube.yaml
@@ -20,6 +20,7 @@ apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
   annotations:
+    "feature.dynatrace.com/automatic-kubernetes-api-monitoring": true
     {{- if ne .Values.platform "google"}}
     "helm.sh/hook": post-install,post-upgrade
     {{ end }}


### PR DESCRIPTION
Hi there! While using the Helm chart in the project I'm currently working on, the team noticed that the `feature.dynatrace.com/automatic-kubernetes-api-monitoring='true'` annotation is missing from the Helm chart, while it's included in the YAML manifests that are automatically generated in the Dynatrace UI when deploying the operator in a K8S cluster (AKS in my case). Once I added this annotation manually (`kubectl -n dynatrace annotate dynakube my-cluster feature.dynatrace.com/automatic-kubernetes-api-monitoring='true'`) the cluster appeared in our dashboard.