### PR TITLE
Update secret.yaml

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/secret.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/secret.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 {{- $platformIsSet := printf "%s" (required "Platform needs to be set to kubernetes, openshift, google" (include "dynatrace-operator.platformSet" .))}}
-{{- if .Values.autoCreateSecret }}
+{{- if .Values.autoCreateSecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
autocreatesecret condition further should be checked enabled true/false. I want to disable autocreatesecret as i would would not like to specify the apitoken and dataingesttoken direct. Instead will you sealedsecret controller to encrypt the token and put the encrypted token in the values.yaml which will eventually decrypted by sealedsecretcontroller and secret will be created/