### PR TITLE
Adding annotations option to dynatrace-kubernetes-monitoring service account

### DIFF
--- a/dynatrace-operator/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
+++ b/dynatrace-operator/chart/default/templates/Common/kubernetes-monitoring/serviceaccount-kubernetes-monitoring.yaml
@@ -19,3 +19,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dynatrace-operator.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccounts.dynatraceKubernetesMonitoring.annotations }} # optionally add annotations for SA - useful for setting AWS IAM roles
+  annotations:
+    {{- .Values.serviceAccounts.dynatraceKubernetesMonitoring.annotations | toYaml | nindent 4 }}
+  {{- end -}}

--- a/dynatrace-operator/chart/default/values.yaml
+++ b/dynatrace-operator/chart/default/values.yaml
@@ -15,6 +15,11 @@
 # may be set to "kubernetes", "openshift", "google"
 platform: "kubernetes"
 
+serviceAccounts: 
+  dynatraceKubernetesMonitoring:
+    annotations: {} # optionally add annotations for SA - useful for setting AWS IAM roles
+      # eks.amazonaws.com/role-arn: arn:aws:iam::<accntid>:role/<roleName>
+
 ### base properties
 
 name: "dynakube"


### PR DESCRIPTION
add conditional annotations support for Kubernetes monitoring service account

- Enable optional annotations on dynatrace-kubernetes-monitoring service account
- Useful for configuring AWS IAM roles and other service account customization
- Maintains backward compatibility when annotations are not specified